### PR TITLE
feat: change to named args in object

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,8 +35,8 @@ const options = {
 
 const cli = meow(options);
 
-const filename = cli.input[0] || null;
+const configPath = cli.input[0] || null;
 const version = cli.flags.version || null;
 const buildNumber = +cli.flags.buildNumber || null;
 
-cordovaSetVersion(filename, version, buildNumber);
+cordovaSetVersion({ configPath, version, buildNumber });

--- a/test/index-tests/build-number.js
+++ b/test/index-tests/build-number.js
@@ -5,11 +5,11 @@ import cordovaSetVersion from '../../src';
 import { tempConfigFile, entryConfigFiles, expectedXmlFiles } from '../configs';
 
 function buildNumberTest() {
-    describe('(buildNumber)', () => {
+    describe('({ buildNumber })', () => {
         it('should override existing buildNumber and preserve existing version', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
-            await cordovaSetVersion(86);
+            await cordovaSetVersion({ buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
         });
@@ -17,7 +17,7 @@ function buildNumberTest() {
         it('should add buildNumber and preserve existing version', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempConfigFile);
 
-            await cordovaSetVersion(86);
+            await cordovaSetVersion({ buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_NO_BUILD));
         });
@@ -25,7 +25,7 @@ function buildNumberTest() {
         it('should override existing buildNumber and not add version', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempConfigFile);
 
-            await cordovaSetVersion(86);
+            await cordovaSetVersion({ buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_NO_VERSION_AND_BUILD));
         });
@@ -33,26 +33,38 @@ function buildNumberTest() {
         it('should add buildNumber and not add version', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempConfigFile);
 
-            await cordovaSetVersion(86);
+            await cordovaSetVersion({ buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_NO_VERSION_AND_NO_BUILD));
         });
 
-        it('should return an error about configPath type', async () => {
+        it('should return an error about buildNumber type', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
             try {
-                await cordovaSetVersion({});
+                await cordovaSetVersion({ buildNumber: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
-                expect(error.message).toContain('configPath');
+                expect(error.message).toContain('buildNumber');
+                expect(error.message).toContain('must be a');
+            }
+        });
+
+        it('should return an error about buildNumber type', async () => {
+            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
+
+            try {
+                await cordovaSetVersion({ buildNumber: 86.2 });
+            } catch (error) {
+                expect(error).not.toBeNil();
+                expect(error.message).toContain('buildNumber');
                 expect(error.message).toContain('must be a');
             }
         });
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(86);
+                await cordovaSetVersion({ buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -64,22 +76,10 @@ function buildNumberTest() {
             fs.copySync(entryConfigFiles.MALFORMED, tempConfigFile);
 
             try {
-                await cordovaSetVersion(86);
+                await cordovaSetVersion({ buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');
-            }
-        });
-
-        it('should return an error about buildNumber type', async () => {
-            fs.copySync(entryConfigFiles.MALFORMED, tempConfigFile);
-
-            try {
-                await cordovaSetVersion(86.2);
-            } catch (error) {
-                expect(error).not.toBeNil();
-                expect(error.message).toContain('buildNumber');
-                expect(error.message).toContain('must be an');
             }
         });
     });

--- a/test/index-tests/config-path-build-number.js
+++ b/test/index-tests/config-path-build-number.js
@@ -5,11 +5,11 @@ import cordovaSetVersion from '../../src';
 import { tempProvidedConfigFile, entryConfigFiles, expectedXmlFiles } from '../configs';
 
 function configPathBuildNumberTest() {
-    describe('(configPath, buildNumber)', () => {
+    describe('({ configPath, buildNumber })', () => {
         it('should override existing buildNumber and preserve existing version', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
         });
@@ -17,7 +17,7 @@ function configPathBuildNumberTest() {
         it('should add buildNumber and preserve existing version', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_NO_BUILD));
         });
@@ -25,7 +25,7 @@ function configPathBuildNumberTest() {
         it('should override existing buildNumber and not add version', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_NO_VERSION_AND_BUILD));
         });
@@ -33,7 +33,7 @@ function configPathBuildNumberTest() {
         it('should add buildNumber and not add version', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_NO_VERSION_AND_NO_BUILD));
         });
@@ -42,7 +42,7 @@ function configPathBuildNumberTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion({}, 86);
+                await cordovaSetVersion({ configPath: {}, buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('configPath');
@@ -50,9 +50,21 @@ function configPathBuildNumberTest() {
             }
         });
 
+        it('should return an error about buildNumber type', async () => {
+            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
+
+            try {
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: {} });
+            } catch (error) {
+                expect(error).not.toBeNil();
+                expect(error.message).toContain('buildNumber');
+                expect(error.message).toContain('must be a');
+            }
+        });
+
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, 86);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -64,7 +76,7 @@ function configPathBuildNumberTest() {
             fs.copySync(entryConfigFiles.MALFORMED, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, 86);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');

--- a/test/index-tests/config-path-version-build-number.js
+++ b/test/index-tests/config-path-version-build-number.js
@@ -5,11 +5,11 @@ import cordovaSetVersion from '../../src';
 import { tempProvidedConfigFile, entryConfigFiles, expectedXmlFiles } from '../configs';
 
 function configPathVersionBuildNumberTest() {
-    describe('(configPath, version, buildNumber)', () => {
+    describe('({ configPath, version, buildNumber })', () => {
         it('should override both existing version and buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_VERSION_AND_BUILD),
@@ -19,7 +19,7 @@ function configPathVersionBuildNumberTest() {
         it('should override existing version and add buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_VERSION_AND_NO_BUILD),
@@ -29,7 +29,7 @@ function configPathVersionBuildNumberTest() {
         it('should add version and override existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_NO_VERSION_AND_BUILD),
@@ -39,7 +39,7 @@ function configPathVersionBuildNumberTest() {
         it('should add version and buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', 86);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_NO_VERSION_AND_NO_BUILD),
@@ -50,7 +50,7 @@ function configPathVersionBuildNumberTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion({}, '2.4.9', 86);
+                await cordovaSetVersion({ configPath: {}, version: '2.4.9', buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('configPath');
@@ -62,7 +62,7 @@ function configPathVersionBuildNumberTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, {}, 86);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: {}, buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('version');
@@ -74,7 +74,7 @@ function configPathVersionBuildNumberTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', {});
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('buildNumber');
@@ -84,7 +84,7 @@ function configPathVersionBuildNumberTest() {
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', 86);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -96,7 +96,7 @@ function configPathVersionBuildNumberTest() {
             fs.copySync(entryConfigFiles.MALFORMED, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', 86);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');

--- a/test/index-tests/config-path-version.js
+++ b/test/index-tests/config-path-version.js
@@ -12,11 +12,11 @@ import {
 } from '../configs';
 
 function configPathVersionTest() {
-    describe('(configPath, version)', () => {
+    describe('({ configPath, version })', () => {
         it('should override existing version and preserve existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9');
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9' });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
         });
@@ -24,7 +24,7 @@ function configPathVersionTest() {
         it('should override existing version and not add buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9');
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9' });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_NO_BUILD));
         });
@@ -32,7 +32,7 @@ function configPathVersionTest() {
         it('should add version and preserve existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9');
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9' });
 
             expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_NO_VERSION_AND_BUILD));
         });
@@ -40,7 +40,7 @@ function configPathVersionTest() {
         it('should add version and not add buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempProvidedConfigFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9');
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9' });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.VERSION_TO_NO_VERSION_AND_NO_BUILD),
@@ -51,7 +51,7 @@ function configPathVersionTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion({}, '2.4.9');
+                await cordovaSetVersion({ configPath: {}, version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('configPath');
@@ -64,7 +64,7 @@ function configPathVersionTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, {});
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('version');
@@ -74,7 +74,7 @@ function configPathVersionTest() {
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, '2.4.9');
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -86,7 +86,7 @@ function configPathVersionTest() {
             fs.copySync(entryConfigFiles.MALFORMED, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile, '2.4.9');
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');
@@ -94,11 +94,11 @@ function configPathVersionTest() {
         });
     });
 
-    describe('(pluginConfigPath, version)', () => {
+    describe('({ pluginConfigPath, version })', () => {
         it('should override existing version', async () => {
             fs.copySync(entryPluginConfigFiles.VERSION, tempProvidedPluginConfigFile);
 
-            await cordovaSetVersion(tempProvidedPluginConfigFile, '2.4.9');
+            await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile, version: '2.4.9' });
 
             expect(readFile(tempProvidedPluginConfigFile)).toBe(readFile(expectedPluginXmlFiles.VERSION_TO_VERSION));
         });
@@ -106,7 +106,7 @@ function configPathVersionTest() {
         it('should add version', async () => {
             fs.copySync(entryPluginConfigFiles.NO_VERSION, tempProvidedPluginConfigFile);
 
-            await cordovaSetVersion(tempProvidedPluginConfigFile, '2.4.9');
+            await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile, version: '2.4.9' });
 
             expect(readFile(tempProvidedPluginConfigFile)).toBe(readFile(expectedPluginXmlFiles.VERSION_TO_NO_VERSION));
         });
@@ -115,7 +115,7 @@ function configPathVersionTest() {
             fs.copySync(entryPluginConfigFiles.VERSION, tempProvidedPluginConfigFile);
 
             try {
-                await cordovaSetVersion({}, '2.4.9');
+                await cordovaSetVersion({ configPath: {}, version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('configPath');
@@ -128,7 +128,7 @@ function configPathVersionTest() {
             fs.copySync(entryPluginConfigFiles.VERSION, tempProvidedPluginConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile, {});
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile, version: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('version');
@@ -138,7 +138,7 @@ function configPathVersionTest() {
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile, '2.4.9');
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile, version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -150,7 +150,7 @@ function configPathVersionTest() {
             fs.copySync(entryPluginConfigFiles.MALFORMED, tempProvidedPluginConfigFile);
 
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile, '2.4.9');
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile, version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');

--- a/test/index-tests/config-path.js
+++ b/test/index-tests/config-path.js
@@ -13,12 +13,12 @@ import {
 import { tempPackageFile, entryPackageFiles } from '../packages';
 
 function configPathTest() {
-    describe('(configPath)', () => {
+    describe('({ configPath })', () => {
         it('should override existing version and preserve existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD),
@@ -29,7 +29,7 @@ function configPathTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempProvidedConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_NO_BUILD),
@@ -40,7 +40,7 @@ function configPathTest() {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempProvidedConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.PACKAGE_VERSION_TO_NO_VERSION_AND_BUILD),
@@ -51,7 +51,7 @@ function configPathTest() {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempProvidedConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
-            await cordovaSetVersion(tempProvidedConfigFile);
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile });
 
             expect(readFile(tempProvidedConfigFile)).toBe(
                 readFile(expectedXmlFiles.PACKAGE_VERSION_TO_NO_VERSION_AND_NO_BUILD),
@@ -62,7 +62,7 @@ function configPathTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
 
             try {
-                await cordovaSetVersion({});
+                await cordovaSetVersion({ configPath: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('configPath');
@@ -72,7 +72,7 @@ function configPathTest() {
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(tempProvidedConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -85,7 +85,7 @@ function configPathTest() {
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');
@@ -95,7 +95,7 @@ function configPathTest() {
         it('should return an error about missing package file', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
             try {
-                await cordovaSetVersion(tempProvidedConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -108,7 +108,7 @@ function configPathTest() {
             fs.copySync(entryPackageFiles.MALFORMED, tempPackageFile);
 
             try {
-                await cordovaSetVersion(tempProvidedConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');
@@ -116,12 +116,12 @@ function configPathTest() {
         });
     });
 
-    describe('(pluginConfigPath)', () => {
+    describe('({ pluginConfigPath })', () => {
         it('should override existing version', async () => {
             fs.copySync(entryPluginConfigFiles.VERSION, tempProvidedPluginConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
-            await cordovaSetVersion(tempProvidedPluginConfigFile);
+            await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile });
 
             expect(readFile(tempProvidedPluginConfigFile)).toBe(
                 readFile(expectedPluginXmlFiles.PACKAGE_VERSION_TO_VERSION),
@@ -132,7 +132,7 @@ function configPathTest() {
             fs.copySync(entryPluginConfigFiles.NO_VERSION, tempProvidedPluginConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
-            await cordovaSetVersion(tempProvidedPluginConfigFile);
+            await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile });
 
             expect(readFile(tempProvidedPluginConfigFile)).toBe(
                 readFile(expectedPluginXmlFiles.PACKAGE_VERSION_TO_NO_VERSION),
@@ -143,7 +143,7 @@ function configPathTest() {
             fs.copySync(entryPluginConfigFiles.VERSION, tempProvidedPluginConfigFile);
 
             try {
-                await cordovaSetVersion({});
+                await cordovaSetVersion({ configPath: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('configPath');
@@ -153,7 +153,7 @@ function configPathTest() {
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -166,7 +166,7 @@ function configPathTest() {
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
 
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');
@@ -176,7 +176,7 @@ function configPathTest() {
         it('should return an error about missing package file', async () => {
             fs.copySync(entryPluginConfigFiles.VERSION, tempProvidedPluginConfigFile);
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -189,7 +189,7 @@ function configPathTest() {
             fs.copySync(entryPackageFiles.MALFORMED, tempPackageFile);
 
             try {
-                await cordovaSetVersion(tempProvidedPluginConfigFile);
+                await cordovaSetVersion({ configPath: tempProvidedPluginConfigFile });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');

--- a/test/index-tests/nulls.js
+++ b/test/index-tests/nulls.js
@@ -7,117 +7,136 @@ import { tempPackageFile, entryPackageFiles } from '../packages';
 
 function nullsTest() {
     describe('nulls', () => {
-        it('(configPath, null)', async () => {
+        beforeEach(() => {
+            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
             fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
-
-            await cordovaSetVersion(tempProvidedConfigFile, null);
-
-            expect(readFile(tempProvidedConfigFile)).toBe(
-                readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD),
-            );
         });
 
-        it('(configPath, null, null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
-            fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
+        it('({})', async () => {
+            await cordovaSetVersion({});
 
-            await cordovaSetVersion(tempProvidedConfigFile, null, null);
-
-            expect(readFile(tempProvidedConfigFile)).toBe(
-                readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD),
-            );
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
         });
 
-        it('(configPath, version, null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
+        it('({ buildNumber: null })', async () => {
+            await cordovaSetVersion({ buildNumber: null });
 
-            await cordovaSetVersion(tempProvidedConfigFile, '2.4.9', null);
-
-            expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
         });
 
-        it('(configPath, null, buildNumber)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempProvidedConfigFile);
+        it('({ version: null })', async () => {
+            await cordovaSetVersion({ buildNumber: null });
 
-            await cordovaSetVersion(tempProvidedConfigFile, null, 86);
-
-            expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
         });
 
-        it('(version, null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
+        it('({ version: null, buildNumber: null })', async () => {
+            await cordovaSetVersion({ version: null, buildNumber: null });
 
-            await cordovaSetVersion('2.4.9', null);
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+        });
+
+        it('({ version: null, buildNumber: 86 })', async () => {
+            await cordovaSetVersion({ version: null, buildNumber: 86 });
+
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
+        });
+
+        it("({ version: '2.4.9', buildNumber: null })", async () => {
+            await cordovaSetVersion({ version: '2.4.9', buildNumber: null });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
         });
 
-        it('(null, version)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
+        it('({ configPath: null })', async () => {
+            await cordovaSetVersion({ configPath: null });
 
-            await cordovaSetVersion(null, '2.4.9');
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+        });
+
+        it('({ configPath: null, buildNumber: null })', async () => {
+            await cordovaSetVersion({ configPath: null, buildNumber: null });
+
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+        });
+
+        it('({ configPath: null, buildNumber: 86 })', async () => {
+            await cordovaSetVersion({ configPath: null, buildNumber: 86 });
+
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
+        });
+
+        it('({ configPath: null, version: null })', async () => {
+            await cordovaSetVersion({ configPath: null, version: null });
+
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+        });
+
+        it('({ configPath: null, version: null, buildNumber: null })', async () => {
+            await cordovaSetVersion({ configPath: null, version: null, buildNumber: null });
+
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+        });
+
+        it('({ configPath: null, version: null, buildNumber: 86 })', async () => {
+            await cordovaSetVersion({ configPath: null, version: null, buildNumber: 86 });
+
+            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
+        });
+
+        it("({ configPath: null, version: '2.4.9' })", async () => {
+            await cordovaSetVersion({ configPath: null, version: '2.4.9' });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
         });
 
-        it('(null, version, null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
-
-            await cordovaSetVersion(null, '2.4.9', null);
+        it("({ configPath: null, version: '2.4.9', buildNumber: null })", async () => {
+            await cordovaSetVersion({ configPath: null, version: '2.4.9', buildNumber: null });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
         });
 
-        it('(null, version, buildNumber)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
-
-            await cordovaSetVersion(null, '2.4.9', 86);
+        it("({ configPath: null, version: '2.4.9', buildNumber: 86 })", async () => {
+            await cordovaSetVersion({ configPath: null, version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_VERSION_AND_BUILD));
         });
 
-        it('(null, buildNumber)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
+        it('({ configPath: tempProvidedConfigFile, buildNumber: null })', async () => {
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, buildNumber: null });
 
-            await cordovaSetVersion(null, 86);
-
-            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
+            expect(readFile(tempProvidedConfigFile)).toBe(
+                readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD),
+            );
         });
 
-        it('(null, null, buildNumber)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
+        it('({ configPath: tempProvidedConfigFile, version: null })', async () => {
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: null });
 
-            await cordovaSetVersion(null, null, 86);
-
-            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
+            expect(readFile(tempProvidedConfigFile)).toBe(
+                readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD),
+            );
         });
 
-        it('(null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
-            fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
+        it('({ configPath: tempProvidedConfigFile, version: null, buildNumber: null })', async () => {
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: null, buildNumber: null });
 
-            await cordovaSetVersion(null);
-
-            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+            expect(readFile(tempProvidedConfigFile)).toBe(
+                readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD),
+            );
         });
 
-        it('(null, null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
-            fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
+        it('({ configPath: tempProvidedConfigFile, version: null, buildNumber: 86 })', async () => {
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: null, buildNumber: 86 });
 
-            await cordovaSetVersion(null, null);
-
-            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+            expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.BUILD_TO_VERSION_AND_BUILD));
         });
 
-        it('(null, null, null)', async () => {
-            fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
-            fs.copySync(entryPackageFiles.GOOD, tempPackageFile);
+        it("({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: null })", async () => {
+            await cordovaSetVersion({ configPath: tempProvidedConfigFile, version: '2.4.9', buildNumber: null });
 
-            await cordovaSetVersion(null, null, null);
-
-            expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.PACKAGE_VERSION_TO_VERSION_AND_BUILD));
+            expect(readFile(tempProvidedConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
         });
     });
 }

--- a/test/index-tests/version-build-number.js
+++ b/test/index-tests/version-build-number.js
@@ -5,11 +5,11 @@ import cordovaSetVersion from '../../src';
 import { tempConfigFile, entryConfigFiles, expectedXmlFiles } from '../configs';
 
 function versionBuildNumberTest() {
-    describe('(version, buildNumber)', () => {
+    describe('({ version, buildNumber })', () => {
         it('should override both existing version and buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9', 86);
+            await cordovaSetVersion({ version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_VERSION_AND_BUILD));
         });
@@ -17,7 +17,7 @@ function versionBuildNumberTest() {
         it('should override existing version and add buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9', 86);
+            await cordovaSetVersion({ version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_VERSION_AND_NO_BUILD));
         });
@@ -25,7 +25,7 @@ function versionBuildNumberTest() {
         it('should add version and override existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9', 86);
+            await cordovaSetVersion({ version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_NO_VERSION_AND_BUILD));
         });
@@ -33,21 +33,21 @@ function versionBuildNumberTest() {
         it('should add version and buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9', 86);
+            await cordovaSetVersion({ version: '2.4.9', buildNumber: 86 });
 
             expect(readFile(tempConfigFile)).toBe(
                 readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_NO_VERSION_AND_NO_BUILD),
             );
         });
 
-        it('should return an error about configPath type', async () => {
+        it('should return an error about version type', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
             try {
-                await cordovaSetVersion({}, 86);
+                await cordovaSetVersion({ version: {}, buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
-                expect(error.message).toContain('configPath');
+                expect(error.message).toContain('version');
                 expect(error.message).toContain('must be a');
             }
         });
@@ -56,7 +56,7 @@ function versionBuildNumberTest() {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
             try {
-                await cordovaSetVersion('2.4.9', {});
+                await cordovaSetVersion({ version: '2.4.9', buildNumber: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('buildNumber');
@@ -66,7 +66,7 @@ function versionBuildNumberTest() {
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion('2.4.9', 86);
+                await cordovaSetVersion({ version: '2.4.9', buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -78,7 +78,7 @@ function versionBuildNumberTest() {
             fs.copySync(entryConfigFiles.MALFORMED, tempConfigFile);
 
             try {
-                await cordovaSetVersion('2.4.9', 86);
+                await cordovaSetVersion({ version: '2.4.9', buildNumber: 86 });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');

--- a/test/index-tests/version.js
+++ b/test/index-tests/version.js
@@ -5,11 +5,11 @@ import cordovaSetVersion from '../../src';
 import { tempConfigFile, entryConfigFiles, expectedXmlFiles } from '../configs';
 
 function versionTest() {
-    describe('(version)', () => {
+    describe('({ version })', () => {
         it('should override existing version and preserve existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9');
+            await cordovaSetVersion({ version: '2.4.9' });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_BUILD));
         });
@@ -17,7 +17,7 @@ function versionTest() {
         it('should override existing version and not add buildNumber', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_NO_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9');
+            await cordovaSetVersion({ version: '2.4.9' });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_VERSION_AND_NO_BUILD));
         });
@@ -25,7 +25,7 @@ function versionTest() {
         it('should add version and preserve existing buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9');
+            await cordovaSetVersion({ version: '2.4.9' });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_NO_VERSION_AND_BUILD));
         });
@@ -33,26 +33,26 @@ function versionTest() {
         it('should add version and not add buildNumber', async () => {
             fs.copySync(entryConfigFiles.NO_VERSION_AND_NO_BUILD, tempConfigFile);
 
-            await cordovaSetVersion('2.4.9');
+            await cordovaSetVersion({ version: '2.4.9' });
 
             expect(readFile(tempConfigFile)).toBe(readFile(expectedXmlFiles.VERSION_TO_NO_VERSION_AND_NO_BUILD));
         });
 
-        it('should return an error about configPath type', async () => {
+        it('should return an error about version type', async () => {
             fs.copySync(entryConfigFiles.VERSION_AND_BUILD, tempConfigFile);
 
             try {
-                await cordovaSetVersion({});
+                await cordovaSetVersion({ version: {} });
             } catch (error) {
                 expect(error).not.toBeNil();
-                expect(error.message).toContain('configPath');
+                expect(error.message).toContain('version');
                 expect(error.message).toContain('must be a');
             }
         });
 
         it('should return an error about missing config file', async () => {
             try {
-                await cordovaSetVersion('2.4.9');
+                await cordovaSetVersion({ version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).toContain('no such file or directory');
@@ -64,7 +64,7 @@ function versionTest() {
             fs.copySync(entryConfigFiles.MALFORMED, tempConfigFile);
 
             try {
-                await cordovaSetVersion('2.4.9');
+                await cordovaSetVersion({ version: '2.4.9' });
             } catch (error) {
                 expect(error).not.toBeNil();
                 expect(error.message).not.toContain('no such file or directory');


### PR DESCRIPTION
args for cordovaSetVersion function are now in an object and are named

BREAKING CHANGE: cordovaSetVersion is no longer called with 3 arguments, but just one