### PR TITLE
fix(tests): make npm test run on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cordova-set-version": "cli.js"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "cz-conventional-changelog": "3.3.0",
         "fs-extra": "10.1.0",
         "husky": "8.0.1",
@@ -4500,6 +4501,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -21721,6 +21740,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "optional": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "jest": "28.1.3",
         "jest-extended": "3.0.2",
         "npm-check": "6.0.1",
+        "rimraf": "^3.0.2",
         "semantic-release": "19.0.5",
         "xo": "0.52.3"
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "description": "CLI and JavaScript API for setting the version in Apache Cordova config.xml",
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "cz-conventional-changelog": "3.3.0",
     "fs-extra": "10.1.0",
     "husky": "8.0.1",
@@ -71,7 +72,8 @@
     "clean": "rm -rf coverage",
     "lint": "xo",
     "lint:fix": "npm run lint -- --fix",
-    "test": "npm run lint && NODE_OPTIONS=--experimental-vm-modules jest --run-in-band",
+    "pretest": "npm run lint",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --run-in-band",
     "test:watch": "npm test -- --watch",
     "wipe": "npm run clean && rm -rf node_modules"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jest": "28.1.3",
     "jest-extended": "3.0.2",
     "npm-check": "6.0.1",
+    "rimraf": "^3.0.2",
     "semantic-release": "19.0.5",
     "xo": "0.52.3"
   },
@@ -69,13 +70,13 @@
     "url": "https://github.com/gligoran/cordova-set-version.git"
   },
   "scripts": {
-    "clean": "rm -rf coverage",
+    "clean": "rimraf coverage",
     "lint": "xo",
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run lint",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --run-in-band",
     "test:watch": "npm test -- --watch",
-    "wipe": "npm run clean && rm -rf node_modules"
+    "wipe": "npm run clean && rimraf node_modules"
   },
   "type": "module",
   "version": "0.0.0",

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -19,7 +19,8 @@ describe('cli', () => {
   test('should run', () => {
     fs.copySync(entryConfigFiles.VERSION_AND_BUILD, temporaryConfigFile);
 
-    execSync('../cli.js -v 2.4.9 -b 86');
+    const cliScriptFile = path.resolve(process.cwd(), '..', 'cli.js');
+    execSync(`${process.execPath} ${cliScriptFile} -v 2.4.9 -b 86`);
 
     expect(readFile(temporaryConfigFile)).toBe(
       readFile(expectedXmlFiles.VERSION_AND_BUILD_TO_VERSION_AND_BUILD),


### PR DESCRIPTION
to explain:

- move pre-test `npm run lint` to `pretest` script
- use `cross-env` to set `NODE_OPTIONS` to `--experimental-vm-modules`
- use `path.resolve()` to locate the root `cli.js` file
- prefix `child_process.execSync()` command with the current environment NodeJS executable path